### PR TITLE
Fix code style with the autoformatter

### DIFF
--- a/inc/preload.php
+++ b/inc/preload.php
@@ -17,7 +17,7 @@ use HM\Lazy_Load_Scripts as LLS;
  * @return void
  */
 function bootstrap(): void {
-    add_action('wp_head', __NAMESPACE__ . '\\print_head_preload_links', 5);
+	add_action( 'wp_head', __NAMESPACE__ . '\\print_head_preload_links', 5 );
 }
 
 /**
@@ -30,7 +30,7 @@ function bootstrap(): void {
  * @return bool
  */
 function validate_data( $data ): bool {
-    return $data === true;
+	return $data === true;
 }
 
 /**
@@ -41,47 +41,47 @@ function validate_data( $data ): bool {
  * @return void
  */
 function print_head_preload_links(): void {
-    $entries = LLS\collect_entries('styles', 'preload', __NAMESPACE__ . '\\validate_data');
-    $assets = wp_styles();
+	$entries = LLS\collect_entries( 'styles', 'preload', __NAMESPACE__ . '\\validate_data' );
+	$assets = wp_styles();
 
-    if (empty($entries) ) {
-        return;
-    }
+	if ( empty( $entries ) ) {
+		return;
+	}
 
-    $wp_version = get_bloginfo('version');
+	$wp_version = get_bloginfo( 'version' );
 
-    foreach ( $entries as $handle => $entry ) {
-        if (empty($entry->src) ) {
-            continue;
-        }
+	foreach ( $entries as $handle => $entry ) {
+		if ( empty( $entry->src ) ) {
+			continue;
+		}
 
-        $src = $entry->src;
+		$src = $entry->src;
 
-        if (strpos($src, '/') === 0 ) {
-            $src = home_url($src);
-        }
+		if ( strpos( $src, '/' ) === 0 ) {
+			$src = home_url( $src );
+		}
 
-        if ($entry->ver === false ) {
-            $src = add_query_arg('ver', $wp_version, $src);
-        }
+		if ( $entry->ver === false ) {
+			$src = add_query_arg( 'ver', $wp_version, $src );
+		}
 
-        $defer = $assets->get_data($handle, 'defer');
+		$defer = $assets->get_data( $handle, 'defer' );
 
-        if (! $defer ) {
-            printf('<link rel="preload" href="%s" as="style" />%s', esc_url_raw($src), "\n");
-            continue;
-        }
+		if ( ! $defer ) {
+			printf( '<link rel="preload" href="%s" as="style" />%s', esc_url_raw( $src ), "\n" );
+			continue;
+		}
 
-        printf('<link rel="preload" id="%s" href="%s" as="style" onload="this.media=\'all\';this.rel=\'stylesheet\';this.onload=null;"/>%s', esc_attr($entry->handle), esc_url_raw($src), "\n");
-        printf('<noscript><link rel="stylesheet" href="%s"></noscript>', esc_url_raw($src), "\n");
+		printf( '<link rel="preload" id="%s" href="%s" as="style" onload="this.media=\'all\';this.rel=\'stylesheet\';this.onload=null;"/>%s', esc_attr( $entry->handle ), esc_url_raw( $src ), "\n" );
+		printf( '<noscript><link rel="stylesheet" href="%s"></noscript>', esc_url_raw( $src ), "\n" );
 
-        $inline_style = $assets->get_data($handle, 'after');
+		$inline_style = $assets->get_data( $handle, 'after' );
 
-		if ($inline_style ) {
-            $assets->print_inline_style($handle, true);
-        }
+		if ( $inline_style ) {
+			$assets->print_inline_style( $handle, true );
+		}
 
 		// Disable style enqueue from the core.
-        wp_dequeue_style($handle);
-    }
+		wp_dequeue_style( $handle );
+	}
 }


### PR DESCRIPTION
Due to prettier misconfiguration, it breaks the code style for `preload.php` file.

This PR is to fix it with phpcs autoformatter.